### PR TITLE
initial commit of R/Python virtual environments guide  

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.DS_Store
+*.Rhistory
+index_files/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.0.38">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>Virtual Environments</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+span.underline{text-decoration: underline;}
+div.column{display: inline-block; vertical-align: top; width: 50%;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+    color: #aaaaaa;
+  }
+pre.numberSource { margin-left: 3em; border-left: 1px solid #aaaaaa;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+code span.al { color: #ff0000; font-weight: bold; } /* Alert */
+code span.an { color: #60a0b0; font-weight: bold; font-style: italic; } /* Annotation */
+code span.at { color: #7d9029; } /* Attribute */
+code span.bn { color: #40a070; } /* BaseN */
+code span.bu { } /* BuiltIn */
+code span.cf { color: #007020; font-weight: bold; } /* ControlFlow */
+code span.ch { color: #4070a0; } /* Char */
+code span.cn { color: #880000; } /* Constant */
+code span.co { color: #60a0b0; font-style: italic; } /* Comment */
+code span.cv { color: #60a0b0; font-weight: bold; font-style: italic; } /* CommentVar */
+code span.do { color: #ba2121; font-style: italic; } /* Documentation */
+code span.dt { color: #902000; } /* DataType */
+code span.dv { color: #40a070; } /* DecVal */
+code span.er { color: #ff0000; font-weight: bold; } /* Error */
+code span.ex { } /* Extension */
+code span.fl { color: #40a070; } /* Float */
+code span.fu { color: #06287e; } /* Function */
+code span.im { } /* Import */
+code span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Information */
+code span.kw { color: #007020; font-weight: bold; } /* Keyword */
+code span.op { color: #666666; } /* Operator */
+code span.ot { color: #007020; } /* Other */
+code span.pp { color: #bc7a00; } /* Preprocessor */
+code span.sc { color: #4070a0; } /* SpecialChar */
+code span.ss { color: #bb6688; } /* SpecialString */
+code span.st { color: #4070a0; } /* String */
+code span.va { color: #19177c; } /* Variable */
+code span.vs { color: #4070a0; } /* VerbatimString */
+code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warning */
+</style>
+
+
+<script src="index_files/libs/clipboard/clipboard.min.js"></script>
+<script src="index_files/libs/quarto-html/quarto.js"></script>
+<script src="index_files/libs/quarto-html/popper.min.js"></script>
+<script src="index_files/libs/quarto-html/tippy.umd.min.js"></script>
+<script src="index_files/libs/quarto-html/anchor.min.js"></script>
+<link href="index_files/libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="index_files/libs/quarto-html/quarto-syntax-highlighting.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="index_files/libs/bootstrap/bootstrap.min.js"></script>
+<link href="index_files/libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="index_files/libs/bootstrap/bootstrap.min.css" rel="stylesheet" id="quarto-bootstrap" data-mode="light">
+
+
+</head>
+
+<body>
+
+<div id="quarto-content" class="page-columns page-rows-contents page-layout-article">
+<div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+  <nav id="TOC" role="doc-toc">
+    <h2 id="toc-title">Table of contents</h2>
+   
+  <ul>
+  <li><a href="#why-should-i-use-a-virtual-environment" id="toc-why-should-i-use-a-virtual-environment" class="nav-link active" data-scroll-target="#why-should-i-use-a-virtual-environment">Why should I use a virtual environment?</a></li>
+  <li><a href="#which-environment-manager-should-i-use" id="toc-which-environment-manager-should-i-use" class="nav-link" data-scroll-target="#which-environment-manager-should-i-use">Which environment manager should I use?</a></li>
+  <li><a href="#how-do-i-set-up-a-virtual-environment" id="toc-how-do-i-set-up-a-virtual-environment" class="nav-link" data-scroll-target="#how-do-i-set-up-a-virtual-environment">How do I set up a virtual environment?</a></li>
+  <li><a href="#additional-resources" id="toc-additional-resources" class="nav-link" data-scroll-target="#additional-resources">Additional Resources</a></li>
+  </ul>
+</nav>
+</div>
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default">
+<div class="quarto-title">
+<h1 class="title">Virtual Environments</h1>
+</div>
+
+
+
+<div class="quarto-title-meta">
+
+    
+    
+  </div>
+  
+
+</header>
+
+<p>This guide is intended to help R and Python users at the Urban Institute start using virtual environments. This guide assumes familiarity with Git and GitHub (see <a href="https://ui-research.github.io/urbngit/">this guide</a> if you are not familiar with these tools) and is focused on helping folks start using virtual environments without having to meaningfully modify their existing workflows.</p>
+<section id="why-should-i-use-a-virtual-environment" class="level2">
+<h2 class="anchored" data-anchor-id="why-should-i-use-a-virtual-environment">Why should I use a virtual environment?</h2>
+<p>Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They can help you reliably reproduce your environment to more easily collaborate with others or run your code on powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a>. They also let you create isolated environments for different projects so that you can, for example, update a package for one project without accidentally breaking other projects.</p>
+<p>Virtual environments accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.</p>
+</section>
+<section id="which-environment-manager-should-i-use" class="level2">
+<h2 class="anchored" data-anchor-id="which-environment-manager-should-i-use">Which environment manager should I use?</h2>
+<p>For R projects, we recommend using <code>renv</code>. For Python projects, we recommend using <code>conda</code>. These are by no means the only environment managers for R and Python, but we’ve found these to be the most reliable and user-friendly for the majority of use cases at Urban.</p>
+<div class="callout-tip callout callout-style-simple callout-captioned">
+<div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-1-contents" aria-controls="callout-1" aria-expanded="false" aria-label="Toggle callout">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-caption-container flex-fill">
+Alternatives for R
+</div>
+<div class="callout-btn-toggle d-inline-block border-0 py-1 ps-1 pe-0 float-end"><i class="callout-toggle"></i></div>
+</div>
+<div id="callout-1" class="callout-1-contents callout-collapse collapse">
+<div class="callout-body-container callout-body">
+<p>Within the R community, <code>renv</code>, developed and <a href="https://github.com/rstudio/renv/">maintained by RStudio</a>, is the de facto virtual environment manager. Older resources might reference <code>packrat</code>, which has been <a href="https://github.com/rstudio/packrat#note">soft-deprecated</a> and is now superseded by <code>renv</code>. <a href="https://cran.r-project.org/web/packages/renv/vignettes/renv.html">According to the developers</a> of <code>renv</code>,</p>
+<blockquote class="blockquote">
+<p>The goal is for <code>renv</code> to be a robust, stable replacement for the Packrat package, with fewer surprises and better default behaviors.</p>
+</blockquote>
+<p>If you’re using R alongside Python, it may make sense to use <code>conda</code> as your environment manager. Documentation for using R with the Anaconda distribution and <code>conda</code> environment manager is available <a href="https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/">here</a>. Alternatively, you can use Python with <code>renv</code>, as documented <a href="https://rstudio.github.io/renv/articles/python.html">here</a>.</p>
+</div>
+</div>
+</div>
+<div class="callout-tip callout callout-style-simple callout-captioned">
+<div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-2-contents" aria-controls="callout-2" aria-expanded="false" aria-label="Toggle callout">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-caption-container flex-fill">
+Alternatives for Python
+</div>
+<div class="callout-btn-toggle d-inline-block border-0 py-1 ps-1 pe-0 float-end"><i class="callout-toggle"></i></div>
+</div>
+<div id="callout-2" class="callout-2-contents callout-collapse collapse">
+<div class="callout-body-container callout-body">
+<p>There is a plethora of virtual environment managers in Python, with a few of the most common being <code>virtualenv</code>, <code>pipenv</code>, <code>poetry</code>, and <code>conda</code>.</p>
+<p>For data science and research use cases, <code>conda</code> is a popular option for several reasons. First, <code>conda</code> is both an environment manager and a package manager. As a result, <code>conda</code> helps install packages and manage dependencies, whereas the others still rely on <code>pip</code> for package management. Unlike other managers, <code>conda</code> also has native support for programming languages beyond Python (including R). Lastly, <code>conda</code> is flexible, letting you install packages from <code>pip</code> and offering <a href="https://docs.conda.io/en/latest/miniconda.html">Miniconda</a> as a lighter-weight alternative to the full Anaconda distribution.</p>
+<p>If you’re using R and Python, <code>conda</code> or <code>renv</code> are good options given their emphasis on interoperability. Documentation for using R with <code>conda</code> is available <a href="https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/">here</a>, and documentation for using Python with <code>renv</code> is available <a href="https://rstudio.github.io/renv/articles/python.html">here</a>.</p>
+</div>
+</div>
+</div>
+</section>
+<section id="how-do-i-set-up-a-virtual-environment" class="level2">
+<h2 class="anchored" data-anchor-id="how-do-i-set-up-a-virtual-environment">How do I set up a virtual environment?</h2>
+<div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">Python</a></li></ul>
+<div class="tab-content">
+<div id="tabset-1-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-1-1-tab">
+<p>To set up a virtual environment for an R project, we recommend using <code>renv</code>. To install <code>renv</code>, use the standard syntax to install R packages from CRAN: <code>install.packages("renv")</code>.</p>
+<div class="callout-note callout callout-style-default callout-captioned">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-caption-container flex-fill">
+Where do I run these commands?
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>All commands below should be run from RStudio within your project’s directory.</p>
+</div>
+</div>
+<ol type="1">
+<li><p><strong>Initialize</strong> a new project-specific environment:</p>
+<div class="sourceCode" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>renv<span class="sc">::</span><span class="fu">init</span>()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div></li>
+<li><p><strong>Install packages</strong> using your usual workflow:</p>
+<div class="sourceCode" id="cb2"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="fu">install.packages</span>(<span class="st">"ggplot2"</span>)      <span class="co"># install from CRAN</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a>renv<span class="sc">::</span><span class="fu">install</span>(<span class="st">"tidyverse/dplyr"</span>) <span class="co"># install from GitHub</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Note that <code>renv</code> can install packages from a <a href="https://rstudio.github.io/renv/articles/renv.html#package-sources">variety of sources</a> including CRAN, GitHub, and Bioconductor.</p></li>
+<li><p><strong>Save</strong> a snapshot of the environment to a file called <code>renv.lock</code>:</p>
+<div class="sourceCode" id="cb3"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>renv<span class="sc">::</span><span class="fu">snapshot</span>()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div></li>
+<li><p><strong>Share</strong> the snapshot of the environment by sending three files to GitHub: <code>renv.lock</code>, <code>.Rprofile</code>, and <code>renv/activate.R</code>.</p>
+<p>Note that running the <code>renv::init()</code> command in the first step automatically updates your <code>.gitignore</code> file (if relevant) to tell Git which <code>renv</code> files to track.</p></li>
+<li><p><strong>Restore</strong> the snapshot of the environment on another computer:</p>
+<div class="sourceCode" id="cb4"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a>renv<span class="sc">::</span><span class="fu">restore</span>()</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div></li>
+<li><p><strong>Repeat</strong> the process. As you and your collaborators install, update, and remove packages, repeat steps 3-5 to save and load the state of your project to the <code>renv.lock</code> file across computers.</p></li>
+</ol>
+</div>
+<div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
+<p>To set up a virtual environment for a Python project, we recommend using <code>conda</code>, which is built into the <a href="https://www.anaconda.com/products/distribution">Anaconda distribution</a> through Anaconda or <a href="https://docs.conda.io/en/latest/miniconda.html">Miniconda</a>. If you haven’t already installed Anaconda, see <a href="https://github.com/UI-Research/python-resources/blob/main/notebooks/anaconda-installation.ipynb">this guide</a> from a previous Python Users Group session. You can verify that <code>conda</code> is installed and running on your computer with <code>conda --version</code>. If you get an error, see the Anaconda <a href="https://conda.io/projects/conda/en/latest/user-guide/troubleshooting.html">troubleshooting guide</a>.</p>
+<div class="callout-note callout callout-style-default callout-captioned">
+<div class="callout-header d-flex align-content-center">
+<div class="callout-icon-container">
+<i class="callout-icon"></i>
+</div>
+<div class="callout-caption-container flex-fill">
+Where do I run these commands?
+</div>
+</div>
+<div class="callout-body-container callout-body">
+<p>All commands below should be run from the Anaconda Prompt or a terminal window (e.g.&nbsp;within RStudio or VS Code) from the root of your project’s directory.</p>
+</div>
+</div>
+<ol type="1">
+<li><p><strong>Initialize</strong> a new environment (optionally specifying a version of Python and/or a list of packages) using one of the options below. You should replace <code>my_env</code> with a descriptive name specific to your project.</p>
+<div class="sourceCode" id="cb5"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a>conda create <span class="op">--</span>name my_env                           <span class="co"># create empty environment  </span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a>conda create <span class="op">--</span>name my_env python<span class="op">==</span><span class="fl">3.7</span>               <span class="co"># create environment with specific Python version </span></span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>conda create <span class="op">--</span>name my_env python<span class="op">==</span><span class="fl">3.7</span> pandas numpy  <span class="co"># create environment with packages installed </span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>It’s best practice to specify packages when initializing the environment to let <code>conda</code> help manage dependencies most effectively.</p></li>
+<li><p><strong>Activate</strong> the environment, again replacing <code>my_env</code> with the name of your environment:</p>
+<div class="sourceCode" id="cb6"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a>conda activate my_env</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div></li>
+<li><p><strong>Install packages</strong> using your usual workflow (optionally specifying the package version) for any packages that you did not include when initializing the environment in the first step:</p>
+<div class="sourceCode" id="cb7"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a>conda install pandas         <span class="co"># install default version of pandas </span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>conda install pandas<span class="op">=</span><span class="fl">0.24.1</span>  <span class="co"># install specific version of pandas </span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>It’s best practice to specify the version number associated with a package to ensure that changes in packages over time don’t affect the reproducibility of your code.</p></li>
+<li><p><strong>Save</strong> a snapshot of the environment to a file called <code>environment.yml</code>.</p>
+<div class="sourceCode" id="cb8"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>conda env export <span class="op">--</span><span class="im">from</span><span class="op">-</span>history <span class="op">&gt;</span> environment.yml</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>The <code>from-history</code> flag is necessary to make your environment file work across platforms.</p>
+<p>Alternatively, you can manually create the <code>environment.yml</code> file in the root of your project directory, where it would follow this structure:</p>
+<div class="sourceCode" id="cb9"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a>name: my_env</span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a>dependencies:</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> python<span class="op">=</span><span class="fl">3.7</span></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> pandas<span class="op">=</span><span class="fl">0.24</span></span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> numpy<span class="op">=</span><span class="fl">1.21</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>If you installed packages using <code>pip</code>, the <code>environment.yml</code> file would follow this structure:</p>
+<div class="sourceCode" id="cb10"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a>name: my_env</span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>dependencies:</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> python<span class="op">=</span><span class="fl">3.7</span></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> pandas<span class="op">=</span><span class="fl">0.24</span></span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> numpy<span class="op">=</span><span class="fl">1.21</span></span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> pip<span class="op">=</span><span class="fl">19.1</span></span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>  <span class="op">-</span> pip:</span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>    <span class="op">-</span> awscli<span class="op">==</span><span class="fl">1.16</span></span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>    <span class="op">-</span> kaggle<span class="op">==</span><span class="fl">1.5</span></span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>Note that packages installed using <code>pip</code> use <code>==</code> to specify the version number, while packages installed from <code>conda</code> use <code>=</code>.</p></li>
+<li><p><strong>Share</strong> the snapshot by sending the <code>environment.yml</code> file to GitHub.</p></li>
+<li><p><strong>Restore</strong> and activate the snapshot of the environment on another computer:</p>
+<div class="sourceCode" id="cb11"><pre class="sourceCode python code-with-copy"><code class="sourceCode python"><span id="cb11-1"><a href="#cb11-1" aria-hidden="true" tabindex="-1"></a>conda env create      </span>
+<span id="cb11-2"><a href="#cb11-2" aria-hidden="true" tabindex="-1"></a>conda activate my_env</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+<p>The <code>conda env create</code> syntax assumes you have a file called <code>environment.yml</code> in your working directory. While you could give this file a different name, we recommend sticking with the convention of naming the file <code>environment.yml</code> and placing it in the root of your project’s directory.</p></li>
+<li><p><strong>Repeat</strong> the process. As you and your collaborators install, update, and remove packages, repeat steps 4-6 to save and load the state of your project to the <code>environment.yml</code> file across computers.</p></li>
+</ol>
+</div>
+</div>
+</div>
+</section>
+<section id="additional-resources" class="level2">
+<h2 class="anchored" data-anchor-id="additional-resources">Additional Resources</h2>
+<div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-2-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-1" role="tab" aria-controls="tabset-2-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-2-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-2" role="tab" aria-controls="tabset-2-2" aria-selected="false" href="">Python</a></li></ul>
+<div class="tab-content">
+<div id="tabset-2-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-2-1-tab">
+<p>For more information, we recommend the official <a href="https://rstudio.github.io/renv/articles/renv.html#package-sources">Introduction to renv</a> and <a href="https://rstudio.github.io/renv/articles/collaborating.html">Collaborating with renv</a> vignettes.</p>
+</div>
+<div id="tabset-2-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-2-2-tab">
+<p>We recommend keeping the official <code>conda</code> <a href="https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf">cheat sheet</a> handy. In addition to the commands included above, a few other commonly used <code>conda</code> commands include:</p>
+<ul>
+<li><code>conda deactivate</code> deactivates the current environment<br>
+</li>
+<li><code>conda list</code> lists all packages in the current environment<br>
+</li>
+<li><code>conda env list</code> lists all environments (with the current active environment asterisked)<br>
+</li>
+<li><code>conda env remove -n my_env</code> deletes the <code>my_env</code> environment</li>
+</ul>
+<p>The official <a href="https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html">documentation</a> and <a href="https://carpentries-incubator.github.io/introduction-to-conda-for-data-scientists/04-sharing-environments/index.html">this guide</a> from the Carpentries are also helpful resources.</p>
+</div>
+</div>
+</div>
+</section>
+
+</main>
+<!-- /main column -->
+<script id="quarto-html-after-body" type="application/javascript">
+window.document.addEventListener("DOMContentLoaded", function (event) {
+  const toggleBodyColorMode = (bsSheetEl) => {
+    const mode = bsSheetEl.getAttribute("data-mode");
+    const bodyEl = window.document.querySelector("body");
+    if (mode === "dark") {
+      bodyEl.classList.add("quarto-dark");
+      bodyEl.classList.remove("quarto-light");
+    } else {
+      bodyEl.classList.add("quarto-light");
+      bodyEl.classList.remove("quarto-dark");
+    }
+  }
+  const toggleBodyColorPrimary = () => {
+    const bsSheetEl = window.document.querySelector("link#quarto-bootstrap");
+    if (bsSheetEl) {
+      toggleBodyColorMode(bsSheetEl);
+    }
+  }
+  toggleBodyColorPrimary();  
+  const icon = "";
+  const anchorJS = new window.AnchorJS();
+  anchorJS.options = {
+    placement: 'right',
+    icon: icon
+  };
+  anchorJS.add('.anchored');
+  const clipboard = new window.ClipboardJS('.code-copy-button', {
+    target: function(trigger) {
+      return trigger.previousElementSibling;
+    }
+  });
+  clipboard.on('success', function(e) {
+    // button target
+    const button = e.trigger;
+    // don't keep focus
+    button.blur();
+    // flash "checked"
+    button.classList.add('code-copy-button-checked');
+    var currentTitle = button.getAttribute("title");
+    button.setAttribute("title", "Copied!");
+    setTimeout(function() {
+      button.setAttribute("title", currentTitle);
+      button.classList.remove('code-copy-button-checked');
+    }, 1000);
+    // clear code selection
+    e.clearSelection();
+  });
+  function tippyHover(el, contentFn) {
+    const config = {
+      allowHTML: true,
+      content: contentFn,
+      maxWidth: 500,
+      delay: 100,
+      arrow: false,
+      appendTo: function(el) {
+          return el.parentElement;
+      },
+      interactive: true,
+      interactiveBorder: 10,
+      theme: 'quarto',
+      placement: 'bottom-start'
+    };
+    window.tippy(el, config); 
+  }
+  const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+  for (var i=0; i<noterefs.length; i++) {
+    const ref = noterefs[i];
+    tippyHover(ref, function() {
+      let href = ref.getAttribute('href');
+      try { href = new URL(href).hash; } catch {}
+      const id = href.replace(/^#\/?/, "");
+      const note = window.document.getElementById(id);
+      return note.innerHTML;
+    });
+  }
+  var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+  for (var i=0; i<bibliorefs.length; i++) {
+    const ref = bibliorefs[i];
+    const cites = ref.parentNode.getAttribute('data-cites').split(' ');
+    tippyHover(ref, function() {
+      var popup = window.document.createElement('div');
+      cites.forEach(function(cite) {
+        var citeDiv = window.document.createElement('div');
+        citeDiv.classList.add('hanging-indent');
+        citeDiv.classList.add('csl-entry');
+        var biblioDiv = window.document.getElementById('ref-' + cite);
+        if (biblioDiv) {
+          citeDiv.innerHTML = biblioDiv.innerHTML;
+        }
+        popup.appendChild(citeDiv);
+      });
+      return popup.innerHTML;
+    });
+  }
+});
+</script>
+</div> <!-- /content -->
+
+
+
+</body></html>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2022-08-17">
+<meta name="dcterms.date" content="2022-08-18">
 
 <title>Virtual Environments</title>
 <style>
@@ -129,7 +129,7 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">August 17, 2022</p>
+      <p class="date">August 18, 2022</p>
     </div>
   </div>
     
@@ -144,15 +144,14 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.</p>
 <p>To make this more concrete, here’s a few situations when setting up a virtual environment can save you several hours (or even days!) of frustration:</p>
 <ul>
-<li>You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in <code>dplyr</code> was updated.</li>
-<li>You need to update your version of <code>pandas</code> for a particular project, but a different project requires an older version of the library.</li>
+<li>You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in a package was updated.</li>
 <li>Your coworker is running into errors running your code because of differences in package versions between your computers.</li>
 <li>You need to use Python 2.7 for a legacy project, while using Python 3.7 for all other projects.</li>
 <li>You want to use a new library that has known compatibility issues with Python 3.8 on Windows computers, so you want to use Python 3.7 for just one specific project.</li>
-<li>You got a new computer and don’t want to spend hours remembering which R packages to install while resolving <code>Error in library(&lt;&gt;): there is no package called ‘&lt;&gt;’</code> errors.</li>
-<li>Your code takes a long time to run locally, so you want to leverage powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a> – or scale to use tens or hundreds or computers simultaneously – but you first need to install the relevant packages on the virtual machine(s).</li>
+<li>You got a new computer and don’t want to spend hours remembering which R packages to install through endless <code>Error in library(&lt;&gt;): there is no package called ‘&lt;&gt;’</code> errors.</li>
+<li>Your code takes a long time to run locally, so you want to leverage powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a> – or scale to use tens, hundreds, or thousands of computers simultaneously – but you first need to install the relevant packages on the virtual machine(s).</li>
 </ul>
-<p>Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility, such as version control, directory management, and data provenance.</p>
+<p>Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility like version control, directory management, or data provenance.</p>
 </section>
 <section id="when-should-i-use-a-virtual-environment" class="level2" data-number="2">
 <h2 data-number="2" class="anchored" data-anchor-id="when-should-i-use-a-virtual-environment"><span class="header-section-number">2</span> When should I use a virtual environment?</h2>
@@ -321,7 +320,7 @@ Where do I run these commands?
 </section>
 <section id="getting-help" class="level2" data-number="6">
 <h2 data-number="6" class="anchored" data-anchor-id="getting-help"><span class="header-section-number">6</span> Getting help</h2>
-<p>Adding a new tool to your workflow can be hard, but we’re here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the #reproducible-research Slack channel with any questions or if you run into issues.</p>
+<p>Adding a new tool to your workflow can be hard, but we’re here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the <strong>#reproducible-research</strong> Slack channel with any questions or if you run into issues.</p>
 </section>
 <section id="obligatory-xkcd-comic" class="level2" data-number="7">
 <h2 data-number="7" class="anchored" data-anchor-id="obligatory-xkcd-comic"><span class="header-section-number">7</span> Obligatory xkcd comic</h2>

--- a/index.html
+++ b/index.html
@@ -6,8 +6,7 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="author" content="Erika Tyagi">
-<meta name="dcterms.date" content="2022-08-15">
+<meta name="dcterms.date" content="2022-08-17">
 
 <title>Virtual Environments</title>
 <style>
@@ -106,9 +105,12 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
    
   <ul>
   <li><a href="#why-should-i-use-a-virtual-environment" id="toc-why-should-i-use-a-virtual-environment" class="nav-link active" data-scroll-target="#why-should-i-use-a-virtual-environment"> <span class="header-section-number">1</span> Why should I use a virtual environment?</a></li>
-  <li><a href="#which-environment-manager-should-i-use" id="toc-which-environment-manager-should-i-use" class="nav-link" data-scroll-target="#which-environment-manager-should-i-use"> <span class="header-section-number">2</span> Which environment manager should I use?</a></li>
-  <li><a href="#how-do-i-set-up-a-virtual-environment" id="toc-how-do-i-set-up-a-virtual-environment" class="nav-link" data-scroll-target="#how-do-i-set-up-a-virtual-environment"> <span class="header-section-number">3</span> How do I set up a virtual environment?</a></li>
-  <li><a href="#additional-resources" id="toc-additional-resources" class="nav-link" data-scroll-target="#additional-resources"> <span class="header-section-number">4</span> Additional Resources</a></li>
+  <li><a href="#when-should-i-use-a-virtual-environment" id="toc-when-should-i-use-a-virtual-environment" class="nav-link" data-scroll-target="#when-should-i-use-a-virtual-environment"> <span class="header-section-number">2</span> When should I use a virtual environment?</a></li>
+  <li><a href="#which-environment-manager-should-i-use" id="toc-which-environment-manager-should-i-use" class="nav-link" data-scroll-target="#which-environment-manager-should-i-use"> <span class="header-section-number">3</span> Which environment manager should I use?</a></li>
+  <li><a href="#how-do-i-set-up-a-virtual-environment" id="toc-how-do-i-set-up-a-virtual-environment" class="nav-link" data-scroll-target="#how-do-i-set-up-a-virtual-environment"> <span class="header-section-number">4</span> How do I set up a virtual environment?</a></li>
+  <li><a href="#additional-resources" id="toc-additional-resources" class="nav-link" data-scroll-target="#additional-resources"> <span class="header-section-number">5</span> Additional resources</a></li>
+  <li><a href="#getting-help" id="toc-getting-help" class="nav-link" data-scroll-target="#getting-help"> <span class="header-section-number">6</span> Getting help</a></li>
+  <li><a href="#obligatory-xkcd-comic" id="toc-obligatory-xkcd-comic" class="nav-link" data-scroll-target="#obligatory-xkcd-comic"> <span class="header-section-number">7</span> Obligatory xkcd comic</a></li>
   </ul>
 </nav>
 </div>
@@ -123,17 +125,11 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 
 <div class="quarto-title-meta">
 
-    <div>
-    <div class="quarto-title-meta-heading">Author</div>
-    <div class="quarto-title-meta-contents">
-             <p>Erika Tyagi </p>
-          </div>
-  </div>
     
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">August 15, 2022</p>
+      <p class="date">August 17, 2022</p>
     </div>
   </div>
     
@@ -145,11 +141,26 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <p>This guide is intended to help R and Python users at the Urban Institute start using virtual environments. This guide assumes familiarity with Git and GitHub (see <a href="https://ui-research.github.io/urbngit/">this guide</a> if you are not familiar with these tools) and is focused on helping folks start using virtual environments without having to meaningfully modify their existing workflows.</p>
 <section id="why-should-i-use-a-virtual-environment" class="level2" data-number="1">
 <h2 data-number="1" class="anchored" data-anchor-id="why-should-i-use-a-virtual-environment"><span class="header-section-number">1</span> Why should I use a virtual environment?</h2>
-<p>Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They can help you reliably reproduce your environment to more easily collaborate with others or run your code on powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a>. They also let you create isolated environments for different projects so that you can, for example, update a package for one project without accidentally breaking other projects.</p>
-<p>Virtual environments accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.</p>
+<p>Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.</p>
+<p>To make this more concrete, here’s a few situations when setting up a virtual environment can save you several hours (or even days!) of frustration:</p>
+<ul>
+<li>You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in <code>dplyr</code> was updated.</li>
+<li>You need to update your version of <code>pandas</code> for a particular project, but a different project requires an older version of the library.</li>
+<li>Your coworker is running into errors running your code because of differences in package versions between your computers.</li>
+<li>You need to use Python 2.7 for a legacy project, while using Python 3.7 for all other projects.</li>
+<li>You want to use a new library that has known compatibility issues with Python 3.8 on Windows computers, so you want to use Python 3.7 for just one specific project.</li>
+<li>You got a new computer and don’t want to spend hours remembering which R packages to install while resolving <code>Error in library(&lt;&gt;): there is no package called ‘&lt;&gt;’</code> errors.</li>
+<li>Your code takes a long time to run locally, so you want to leverage powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a> – or scale to use tens or hundreds or computers simultaneously – but you first need to install the relevant packages on the virtual machine(s).</li>
+</ul>
+<p>Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility, such as version control, directory management, and data provenance.</p>
 </section>
-<section id="which-environment-manager-should-i-use" class="level2" data-number="2">
-<h2 data-number="2" class="anchored" data-anchor-id="which-environment-manager-should-i-use"><span class="header-section-number">2</span> Which environment manager should I use?</h2>
+<section id="when-should-i-use-a-virtual-environment" class="level2" data-number="2">
+<h2 data-number="2" class="anchored" data-anchor-id="when-should-i-use-a-virtual-environment"><span class="header-section-number">2</span> When should I use a virtual environment?</h2>
+<p>Ideally, always. You’ll be more likely to regret NOT setting up a virtual environment for a project down the line than to regret spending a few minutes doing so for a project that didn’t necessarily require one. Getting into the habit of using virtual environments for smaller projects will also help you develop confidence when using them for larger projects with more collaborators and complex dependencies.</p>
+<p>While the best time to set up a virtual environment for a project is at the very beginning (right after initializing your GitHub repository), the second best time is right now – whether you’re halfway through writing your code, ready to publish your results, or have already published your analysis.</p>
+</section>
+<section id="which-environment-manager-should-i-use" class="level2" data-number="3">
+<h2 data-number="3" class="anchored" data-anchor-id="which-environment-manager-should-i-use"><span class="header-section-number">3</span> Which environment manager should I use?</h2>
 <p>For R projects, we recommend using <code>renv</code>. For Python projects, we recommend using <code>conda</code>. These are by no means the only environment managers for R and Python, but we’ve found these to be the most reliable and user-friendly for the majority of use cases at Urban.</p>
 <div class="callout-tip callout callout-style-simple callout-captioned">
 <div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-1-contents" aria-controls="callout-1" aria-expanded="false" aria-label="Toggle callout">
@@ -190,8 +201,8 @@ Alternatives for Python
 </div>
 </div>
 </section>
-<section id="how-do-i-set-up-a-virtual-environment" class="level2" data-number="3">
-<h2 data-number="3" class="anchored" data-anchor-id="how-do-i-set-up-a-virtual-environment"><span class="header-section-number">3</span> How do I set up a virtual environment?</h2>
+<section id="how-do-i-set-up-a-virtual-environment" class="level2" data-number="4">
+<h2 data-number="4" class="anchored" data-anchor-id="how-do-i-set-up-a-virtual-environment"><span class="header-section-number">4</span> How do I set up a virtual environment?</h2>
 <div class="panel-tabset">
 <ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">Python</a></li></ul>
 <div class="tab-content">
@@ -284,8 +295,8 @@ Where do I run these commands?
 </div>
 </div>
 </section>
-<section id="additional-resources" class="level2" data-number="4">
-<h2 data-number="4" class="anchored" data-anchor-id="additional-resources"><span class="header-section-number">4</span> Additional Resources</h2>
+<section id="additional-resources" class="level2" data-number="5">
+<h2 data-number="5" class="anchored" data-anchor-id="additional-resources"><span class="header-section-number">5</span> Additional resources</h2>
 <div class="panel-tabset">
 <ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-2-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-1" role="tab" aria-controls="tabset-2-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-2-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-2" role="tab" aria-controls="tabset-2-2" aria-selected="false" href="">Python</a></li></ul>
 <div class="tab-content">
@@ -307,6 +318,41 @@ Where do I run these commands?
 </div>
 </div>
 </div>
+</section>
+<section id="getting-help" class="level2" data-number="6">
+<h2 data-number="6" class="anchored" data-anchor-id="getting-help"><span class="header-section-number">6</span> Getting help</h2>
+<p>Adding a new tool to your workflow can be hard, but we’re here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the #reproducible-research Slack channel with any questions or if you run into issues.</p>
+</section>
+<section id="obligatory-xkcd-comic" class="level2" data-number="7">
+<h2 data-number="7" class="anchored" data-anchor-id="obligatory-xkcd-comic"><span class="header-section-number">7</span> Obligatory xkcd comic</h2>
+<p>I couldn’t pick just one, so here’s three:</p>
+<div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-3-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-3-1" role="tab" aria-controls="tabset-3-1" aria-selected="true" href="">Dependency</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-3-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-3-2" role="tab" aria-controls="tabset-3-2" aria-selected="false" href="">Python Environment</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-3-3-tab" data-bs-toggle="tab" data-bs-target="#tabset-3-3" role="tab" aria-controls="tabset-3-3" aria-selected="false" href="">Workflow</a></li></ul>
+<div class="tab-content">
+<div id="tabset-3-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-3-1-tab">
+<div class="quarto-figure quarto-figure-center">
+<figure class="figure">
+<p><a href="https://xkcd.com/2347/" data-fig-align="center"><img src="https://imgs.xkcd.com/comics/dependency.png" class="img-fluid figure-img"></a></p>
+</figure>
+</div>
+</div>
+<div id="tabset-3-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-3-2-tab">
+<div class="quarto-figure quarto-figure-center">
+<figure class="figure">
+<p><a href="https://xkcd.com/1987/" data-fig-align="center"><img src="https://imgs.xkcd.com/comics/python_environment.png" class="img-fluid figure-img"></a></p>
+</figure>
+</div>
+</div>
+<div id="tabset-3-3" class="tab-pane" role="tabpanel" aria-labelledby="tabset-3-3-tab">
+<div class="quarto-figure quarto-figure-center">
+<figure class="figure">
+<p><a href="https://xkcd.com/1172/" data-fig-align="center"><img src="https://imgs.xkcd.com/comics/workflow.png" class="img-fluid figure-img"></a></p>
+</figure>
+</div>
+</div>
+</div>
+</div>
+<hr>
 </section>
 
 </main>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,8 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-<meta name="dcterms.date" content="2022-08-18">
+<meta name="author" content="Erika Tyagi">
+<meta name="dcterms.date" content="2022-08-19">
 
 <title>Virtual Environments</title>
 <style>
@@ -119,17 +120,24 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 <header id="title-block-header" class="quarto-title-block default">
 <div class="quarto-title">
 <h1 class="title">Virtual Environments</h1>
+<p class="subtitle lead">Introduction to Virtual Environments with R and Python at the Urban Institute</p>
 </div>
 
 
 
 <div class="quarto-title-meta">
 
+    <div>
+    <div class="quarto-title-meta-heading">Author</div>
+    <div class="quarto-title-meta-contents">
+             <p>Erika Tyagi </p>
+          </div>
+  </div>
     
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">August 18, 2022</p>
+      <p class="date">August 19, 2022</p>
     </div>
   </div>
     
@@ -194,7 +202,7 @@ Alternatives for Python
 <div id="callout-2" class="callout-2-contents callout-collapse collapse">
 <div class="callout-body-container callout-body">
 <p>There is a plethora of virtual environment managers in Python, with a few of the most common being <code>virtualenv</code>, <code>pipenv</code>, <code>poetry</code>, and <code>conda</code>.</p>
-<p>For data science and research use cases, <code>conda</code> is a popular option for several reasons. First, <code>conda</code> is both an environment manager and a package manager. As a result, <code>conda</code> helps install packages and manage dependencies, whereas the others still rely on <code>pip</code> for package management. Unlike other managers, <code>conda</code> also has native support for programming languages beyond Python (including R). Lastly, <code>conda</code> is flexible, letting you install packages from <code>pip</code> and offering <a href="https://docs.conda.io/en/latest/miniconda.html">Miniconda</a> as a lighter-weight alternative to the full Anaconda distribution.</p>
+<p>For data science and research use cases, <code>conda</code> is a popular option for several reasons. First, <code>conda</code> is both an environment manager and a package manager. As a result, <code>conda</code> helps install packages and manage dependencies, whereas other tools rely on <code>pip</code> for package management. Unlike other managers, <code>conda</code> also has native support for programming languages beyond Python (including R). Lastly, <code>conda</code> is extensible, letting you install packages from <code>pip</code>, for example, and offering <a href="https://docs.conda.io/en/latest/miniconda.html">Miniconda</a> as a lighter-weight alternative or <a href="https://mamba.readthedocs.io/en/latest/index.html">Mambda</a> as an even faster “drop-in replacement” for <code>conda</code>.</p>
 <p>If you’re using R and Python, <code>conda</code> or <code>renv</code> are good options given their emphasis on interoperability. Documentation for using R with <code>conda</code> is available <a href="https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/">here</a>, and documentation for using Python with <code>renv</code> is available <a href="https://rstudio.github.io/renv/articles/python.html">here</a>.</p>
 </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
 
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
+<meta name="author" content="Erika Tyagi">
+<meta name="dcterms.date" content="2022-08-15">
 
 <title>Virtual Environments</title>
 <style>
@@ -103,10 +105,10 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
     <h2 id="toc-title">Table of contents</h2>
    
   <ul>
-  <li><a href="#why-should-i-use-a-virtual-environment" id="toc-why-should-i-use-a-virtual-environment" class="nav-link active" data-scroll-target="#why-should-i-use-a-virtual-environment">Why should I use a virtual environment?</a></li>
-  <li><a href="#which-environment-manager-should-i-use" id="toc-which-environment-manager-should-i-use" class="nav-link" data-scroll-target="#which-environment-manager-should-i-use">Which environment manager should I use?</a></li>
-  <li><a href="#how-do-i-set-up-a-virtual-environment" id="toc-how-do-i-set-up-a-virtual-environment" class="nav-link" data-scroll-target="#how-do-i-set-up-a-virtual-environment">How do I set up a virtual environment?</a></li>
-  <li><a href="#additional-resources" id="toc-additional-resources" class="nav-link" data-scroll-target="#additional-resources">Additional Resources</a></li>
+  <li><a href="#why-should-i-use-a-virtual-environment" id="toc-why-should-i-use-a-virtual-environment" class="nav-link active" data-scroll-target="#why-should-i-use-a-virtual-environment"> <span class="header-section-number">1</span> Why should I use a virtual environment?</a></li>
+  <li><a href="#which-environment-manager-should-i-use" id="toc-which-environment-manager-should-i-use" class="nav-link" data-scroll-target="#which-environment-manager-should-i-use"> <span class="header-section-number">2</span> Which environment manager should I use?</a></li>
+  <li><a href="#how-do-i-set-up-a-virtual-environment" id="toc-how-do-i-set-up-a-virtual-environment" class="nav-link" data-scroll-target="#how-do-i-set-up-a-virtual-environment"> <span class="header-section-number">3</span> How do I set up a virtual environment?</a></li>
+  <li><a href="#additional-resources" id="toc-additional-resources" class="nav-link" data-scroll-target="#additional-resources"> <span class="header-section-number">4</span> Additional Resources</a></li>
   </ul>
 </nav>
 </div>
@@ -121,7 +123,19 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 
 <div class="quarto-title-meta">
 
+    <div>
+    <div class="quarto-title-meta-heading">Author</div>
+    <div class="quarto-title-meta-contents">
+             <p>Erika Tyagi </p>
+          </div>
+  </div>
     
+    <div>
+    <div class="quarto-title-meta-heading">Published</div>
+    <div class="quarto-title-meta-contents">
+      <p class="date">August 15, 2022</p>
+    </div>
+  </div>
     
   </div>
   
@@ -129,13 +143,13 @@ code span.wa { color: #60a0b0; font-weight: bold; font-style: italic; } /* Warni
 </header>
 
 <p>This guide is intended to help R and Python users at the Urban Institute start using virtual environments. This guide assumes familiarity with Git and GitHub (see <a href="https://ui-research.github.io/urbngit/">this guide</a> if you are not familiar with these tools) and is focused on helping folks start using virtual environments without having to meaningfully modify their existing workflows.</p>
-<section id="why-should-i-use-a-virtual-environment" class="level2">
-<h2 class="anchored" data-anchor-id="why-should-i-use-a-virtual-environment">Why should I use a virtual environment?</h2>
+<section id="why-should-i-use-a-virtual-environment" class="level2" data-number="1">
+<h2 data-number="1" class="anchored" data-anchor-id="why-should-i-use-a-virtual-environment"><span class="header-section-number">1</span> Why should I use a virtual environment?</h2>
 <p>Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They can help you reliably reproduce your environment to more easily collaborate with others or run your code on powerful <a href="http://tech-tools.urban.org/ec2-submission/">virtual computers in the cloud</a>. They also let you create isolated environments for different projects so that you can, for example, update a package for one project without accidentally breaking other projects.</p>
 <p>Virtual environments accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.</p>
 </section>
-<section id="which-environment-manager-should-i-use" class="level2">
-<h2 class="anchored" data-anchor-id="which-environment-manager-should-i-use">Which environment manager should I use?</h2>
+<section id="which-environment-manager-should-i-use" class="level2" data-number="2">
+<h2 data-number="2" class="anchored" data-anchor-id="which-environment-manager-should-i-use"><span class="header-section-number">2</span> Which environment manager should I use?</h2>
 <p>For R projects, we recommend using <code>renv</code>. For Python projects, we recommend using <code>conda</code>. These are by no means the only environment managers for R and Python, but we’ve found these to be the most reliable and user-friendly for the majority of use cases at Urban.</p>
 <div class="callout-tip callout callout-style-simple callout-captioned">
 <div class="callout-header d-flex align-content-center" data-bs-toggle="collapse" data-bs-target=".callout-1-contents" aria-controls="callout-1" aria-expanded="false" aria-label="Toggle callout">
@@ -176,8 +190,8 @@ Alternatives for Python
 </div>
 </div>
 </section>
-<section id="how-do-i-set-up-a-virtual-environment" class="level2">
-<h2 class="anchored" data-anchor-id="how-do-i-set-up-a-virtual-environment">How do I set up a virtual environment?</h2>
+<section id="how-do-i-set-up-a-virtual-environment" class="level2" data-number="3">
+<h2 data-number="3" class="anchored" data-anchor-id="how-do-i-set-up-a-virtual-environment"><span class="header-section-number">3</span> How do I set up a virtual environment?</h2>
 <div class="panel-tabset">
 <ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">Python</a></li></ul>
 <div class="tab-content">
@@ -270,8 +284,8 @@ Where do I run these commands?
 </div>
 </div>
 </section>
-<section id="additional-resources" class="level2">
-<h2 class="anchored" data-anchor-id="additional-resources">Additional Resources</h2>
+<section id="additional-resources" class="level2" data-number="4">
+<h2 data-number="4" class="anchored" data-anchor-id="additional-resources"><span class="header-section-number">4</span> Additional Resources</h2>
 <div class="panel-tabset">
 <ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-2-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-1" role="tab" aria-controls="tabset-2-1" aria-selected="true" href="">R</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-2-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-2-2" role="tab" aria-controls="tabset-2-2" aria-selected="false" href="">Python</a></li></ul>
 <div class="tab-content">

--- a/index.qmd
+++ b/index.qmd
@@ -1,10 +1,12 @@
 ---
-title: "Virtual Environments"
+title: Virtual Environments
+author: Erika Tyagi
+date: "`r format(Sys.time(), '%d %B, %Y')`"
 format:
   html:
     toc: true
-theme: 
-    - www/web_report.scss
+    theme: www/urbn.scss
+    number-sections: true
 editor: visual
 execute:
   echo: true

--- a/index.qmd
+++ b/index.qmd
@@ -1,6 +1,5 @@
 ---
 title: Virtual Environments
-author: Erika Tyagi
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 format:
   html:
@@ -17,9 +16,25 @@ This guide is intended to help R and Python users at the Urban Institute start u
 
 ## Why should I use a virtual environment? 
 
-Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They can help you reliably reproduce your environment to more easily collaborate with others or run your code on powerful [virtual computers in the cloud](http://tech-tools.urban.org/ec2-submission/). They also let you create isolated environments for different projects so that you can, for example, update a package for one project without accidentally breaking other projects. 
+Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.  
 
-Virtual environments accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.   
+To make this more concrete, here's a few situations when setting up a virtual environment can save you several hours (or even days!) of frustration: 
+
+* You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in `dplyr` was updated. 
+* You need to update your version of `pandas` for a particular project, but a different project requires an older version of the library. 
+* Your coworker is running into errors running your code because of differences in package versions between your computers. 
+* You need to use Python 2.7 for a legacy project, while using Python 3.7 for all other projects. 
+* You want to use a new library that has known compatibility issues with Python 3.8 on Windows computers, so you want to use Python 3.7 for just one specific project. 
+* You got a new computer and don't want to spend hours remembering which R packages to install while resolving `Error in library(<>): there is no package called ‘<>’` errors. 
+* Your code takes a long time to run locally, so you want to leverage powerful [virtual computers in the cloud](http://tech-tools.urban.org/ec2-submission/) – or scale to use tens or hundreds or computers simultaneously – but you first need to install the relevant packages on the virtual machine(s). 
+
+Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility, such as version control, directory management, and data provenance. 
+
+## When should I use a virtual environment? 
+
+Ideally, always. You'll be more likely to regret NOT setting up a virtual environment for a project down the line than to regret spending a few minutes doing so for a project that didn't necessarily require one. Getting into the habit of using virtual environments for smaller projects will also help you develop confidence when using them for larger projects with more collaborators and complex dependencies.
+
+While the best time to set up a virtual environment for a project is at the very beginning (right after initializing your GitHub repository), the second best time is right now – whether you're halfway through writing your code, ready to publish your results, or have already published your analysis. 
 
 ## Which environment manager should I use? 
 
@@ -173,7 +188,7 @@ All commands below should be run from the Anaconda Prompt or a terminal window (
 
 :::
 
-## Additional Resources 
+## Additional resources 
 
 ::: {.panel-tabset}
 
@@ -194,3 +209,26 @@ In addition to the commands included above, a few other commonly used `conda` co
 The official [documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) and [this guide](https://carpentries-incubator.github.io/introduction-to-conda-for-data-scientists/04-sharing-environments/index.html) from the Carpentries are also helpful resources. 
 
 :::
+
+## Getting help 
+
+Adding a new tool to your workflow can be hard, but we're here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the #reproducible-research Slack channel with any questions or if you run into issues. 
+
+## Obligatory xkcd comic 
+
+I couldn't pick just one, so here's three: 
+
+::: {.panel-tabset}
+
+### Dependency 
+[![](https://imgs.xkcd.com/comics/dependency.png)](https://xkcd.com/2347/){fig-align="center"}
+
+### Python Environment 
+[![](https://imgs.xkcd.com/comics/python_environment.png)](https://xkcd.com/1987/){fig-align="center"}
+
+### Workflow
+[![](https://imgs.xkcd.com/comics/workflow.png)](https://xkcd.com/1172/){fig-align="center"}
+
+:::
+
+---

--- a/index.qmd
+++ b/index.qmd
@@ -20,15 +20,14 @@ Virtual environments promote reproducibility by letting you let you specify proj
 
 To make this more concrete, here's a few situations when setting up a virtual environment can save you several hours (or even days!) of frustration: 
 
-* You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in `dplyr` was updated. 
-* You need to update your version of `pandas` for a particular project, but a different project requires an older version of the library. 
+* You published an analysis based on 2021 data. A year later, you want to update the analysis with 2022 data, but your code no longer works because a function in a package was updated. 
 * Your coworker is running into errors running your code because of differences in package versions between your computers. 
 * You need to use Python 2.7 for a legacy project, while using Python 3.7 for all other projects. 
 * You want to use a new library that has known compatibility issues with Python 3.8 on Windows computers, so you want to use Python 3.7 for just one specific project. 
-* You got a new computer and don't want to spend hours remembering which R packages to install while resolving `Error in library(<>): there is no package called ‘<>’` errors. 
-* Your code takes a long time to run locally, so you want to leverage powerful [virtual computers in the cloud](http://tech-tools.urban.org/ec2-submission/) – or scale to use tens or hundreds or computers simultaneously – but you first need to install the relevant packages on the virtual machine(s). 
+* You got a new computer and don't want to spend hours remembering which R packages to install through endless `Error in library(<>): there is no package called ‘<>’` errors. 
+* Your code takes a long time to run locally, so you want to leverage powerful [virtual computers in the cloud](http://tech-tools.urban.org/ec2-submission/) – or scale to use tens, hundreds, or thousands of computers simultaneously – but you first need to install the relevant packages on the virtual machine(s). 
 
-Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility, such as version control, directory management, and data provenance. 
+Importantly, virtual environments are just one piece of reproducible research workflows – they are NOT replacements for other important components of reproducibility like version control, directory management, or data provenance. 
 
 ## When should I use a virtual environment? 
 
@@ -212,7 +211,7 @@ The official [documentation](https://docs.conda.io/projects/conda/en/latest/user
 
 ## Getting help 
 
-Adding a new tool to your workflow can be hard, but we're here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the #reproducible-research Slack channel with any questions or if you run into issues. 
+Adding a new tool to your workflow can be hard, but we're here to help! Feel free to email Erika Tyagi (etyagi@urban.org) or drop a message in the **#reproducible-research** Slack channel with any questions or if you run into issues. 
 
 ## Obligatory xkcd comic 
 

--- a/index.qmd
+++ b/index.qmd
@@ -1,0 +1,194 @@
+---
+title: "Virtual Environments"
+format:
+  html:
+    toc: true
+theme: 
+    - www/web_report.scss
+editor: visual
+execute:
+  echo: true
+  eval: false
+---
+
+This guide is intended to help R and Python users at the Urban Institute start using virtual environments. This guide assumes familiarity with Git and GitHub (see [this guide](https://ui-research.github.io/urbngit/) if you are not familiar with these tools) and is focused on helping folks start using virtual environments without having to meaningfully modify their existing workflows. 
+
+## Why should I use a virtual environment? 
+
+Virtual environments promote reproducibility by letting you let you specify project-specific versions of packages. They can help you reliably reproduce your environment to more easily collaborate with others or run your code on powerful [virtual computers in the cloud](http://tech-tools.urban.org/ec2-submission/). They also let you create isolated environments for different projects so that you can, for example, update a package for one project without accidentally breaking other projects. 
+
+Virtual environments accomplish this by making it easy to take a snapshot of the version of packages used in a project and restore that snapshot on other computers. They also make it easy to switch between snapshots on a single computer as you switch between projects.   
+
+## Which environment manager should I use? 
+
+For R projects, we recommend using `renv`. For Python projects, we recommend using `conda`. These are by no means the only environment managers for R and Python, but we've found these to be the most reliable and user-friendly for the majority of use cases at Urban. 
+
+:::{.callout-tip collapse="true" appearance="simple"}
+### Alternatives for R
+
+Within the R community, `renv`, developed and [maintained by RStudio](https://github.com/rstudio/renv/), is the de facto virtual environment manager. Older resources might reference `packrat`, which has been [soft-deprecated](https://github.com/rstudio/packrat#note) and is now superseded by `renv`. [According to the developers](https://cran.r-project.org/web/packages/renv/vignettes/renv.html) of `renv`, 
+
+> The goal is for `renv` to be a robust, stable replacement for the Packrat package, with fewer surprises and better default behaviors.
+
+If you're using R alongside Python, it may make sense to use `conda` as your environment manager. Documentation for using R with the Anaconda distribution and `conda` environment manager is available [here](https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/). Alternatively, you can use Python with `renv`, as documented [here](https://rstudio.github.io/renv/articles/python.html). 
+:::
+
+:::{.callout-tip collapse="true" appearance="simple"}
+### Alternatives for Python
+There is a plethora of virtual environment managers in Python, with a few of the most common being `virtualenv`, `pipenv`, `poetry`, and `conda`. 
+
+For data science and research use cases, `conda` is a popular option for several reasons. First, `conda` is both an environment manager and a package manager. As a result, `conda` helps install packages and manage dependencies, whereas the others still rely on `pip` for package management. Unlike other managers, `conda` also has native support for programming languages beyond Python (including R). Lastly, `conda` is flexible, letting you install packages from `pip` and offering [Miniconda](https://docs.conda.io/en/latest/miniconda.html) as a lighter-weight alternative to the full Anaconda distribution. 
+
+If you're using R and Python, `conda` or `renv` are good options given their emphasis on interoperability. Documentation for using R with `conda` is available [here](https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/), and documentation for using Python with `renv` is available [here](https://rstudio.github.io/renv/articles/python.html). 
+:::
+
+## How do I set up a virtual environment? 
+
+::: {.panel-tabset}
+
+### R 
+
+To set up a virtual environment for an R project, we recommend using `renv`. To install `renv`, use the standard syntax to install R packages from CRAN: `install.packages("renv")`. 
+
+:::{.callout-note}
+## Where do I run these commands? 
+All commands below should be run from RStudio within your project's directory. 
+:::
+
+1. **Initialize** a new project-specific environment: 
+
+    ```{.r}
+    renv::init()
+    ```
+    
+2. **Install packages** using your usual workflow: 
+
+    ```{.r}
+    install.packages("ggplot2")      # install from CRAN
+    renv::install("tidyverse/dplyr") # install from GitHub
+    ```
+
+    Note that `renv` can install packages from a [variety of sources](https://rstudio.github.io/renv/articles/renv.html#package-sources) including CRAN, GitHub, and Bioconductor. 
+
+3. **Save** a snapshot of the environment to a file called `renv.lock`: 
+
+    ```{.r}
+    renv::snapshot()
+    ```
+
+4. **Share** the snapshot of the environment by sending three files to GitHub: `renv.lock`, `.Rprofile`, and `renv/activate.R`. 
+
+    Note that running the `renv::init()` command in the first step automatically updates your `.gitignore` file (if relevant) to tell Git which `renv` files to track. 
+
+5. **Restore** the snapshot of the environment on another computer: 
+
+    ```{.r}
+    renv::restore()
+    ```
+
+6. **Repeat** the process. As you and your collaborators install, update, and remove packages, repeat steps 3-5 to save and load the state of your project to the `renv.lock` file across computers. 
+
+### Python 
+
+To set up a virtual environment for a Python project, we recommend using `conda`, which is built into the [Anaconda distribution](https://www.anaconda.com/products/distribution) through Anaconda or [Miniconda](https://docs.conda.io/en/latest/miniconda.html). If you haven't already installed Anaconda, see [this guide](https://github.com/UI-Research/python-resources/blob/main/notebooks/anaconda-installation.ipynb) from a previous Python Users Group session. You can verify that `conda` is installed and running on your computer with `conda --version`. If you get an error, see the Anaconda [troubleshooting guide](https://conda.io/projects/conda/en/latest/user-guide/troubleshooting.html). 
+
+:::{.callout-note}
+## Where do I run these commands? 
+All commands below should be run from the Anaconda Prompt or a terminal window (e.g. within RStudio or VS Code) from the root of your project's directory. 
+:::
+
+1. **Initialize** a new environment (optionally specifying a version of Python and/or a list of packages) using one of the options below. You should replace `my_env` with a descriptive name specific to your project. 
+
+    ```{.python}
+    conda create --name my_env                           # create empty environment  
+    conda create --name my_env python==3.7               # create environment with specific Python version 
+    conda create --name my_env python==3.7 pandas numpy  # create environment with packages installed 
+    ```
+
+    It's best practice to specify packages when initializing the environment to let `conda` help manage dependencies most effectively. 
+
+2. **Activate** the environment, again replacing `my_env` with the name of your environment: 
+
+    ```{.python}
+    conda activate my_env
+    ```
+
+3. **Install packages** using your usual workflow (optionally specifying the package version) for any packages that you did not include when initializing the environment in the first step: 
+
+    ```{.python}
+    conda install pandas         # install default version of pandas 
+    conda install pandas=0.24.1  # install specific version of pandas 
+    ```
+
+    It's best practice to specify the version number associated with a package to ensure that changes in packages over time don't affect the reproducibility of your code. 
+
+4. **Save** a snapshot of the environment to a file called `environment.yml`. 
+
+    ```{.python}
+    conda env export --from-history > environment.yml
+    ```
+
+    The `from-history` flag is necessary to make your environment file work across platforms. 
+    
+    Alternatively, you can manually create the `environment.yml` file in the root of your project directory, where it would follow this structure: 
+
+    ```{.python}
+    name: my_env
+    dependencies:
+      - python=3.7
+      - pandas=0.24
+      - numpy=1.21
+    ```
+
+    If you installed packages using `pip`, the `environment.yml` file would follow this structure: 
+    
+    ```{.python}
+    name: my_env
+    dependencies:
+      - python=3.7
+      - pandas=0.24
+      - numpy=1.21
+      - pip=19.1
+      - pip:
+        - awscli==1.16
+        - kaggle==1.5
+    ```
+
+    Note that packages installed using `pip` use `==` to specify the version number, while packages installed from `conda` use `=`. 
+
+5. **Share** the snapshot by sending the `environment.yml` file to GitHub. 
+
+6. **Restore** and activate the snapshot of the environment on another computer: 
+
+    ```{.python}
+    conda env create      
+    conda activate my_env
+    ```
+
+    The `conda env create` syntax assumes you have a file called `environment.yml` in your working directory. While you could give this file a different name, we recommend sticking with the convention of naming the file `environment.yml` and placing it in the root of your project's directory. 
+
+7. **Repeat** the process. As you and your collaborators install, update, and remove packages, repeat steps 4-6 to save and load the state of your project to the `environment.yml` file across computers. 
+
+:::
+
+## Additional Resources 
+
+::: {.panel-tabset}
+
+### R
+
+For more information, we recommend the official [Introduction to renv](https://rstudio.github.io/renv/articles/renv.html#package-sources) and [Collaborating with renv](https://rstudio.github.io/renv/articles/collaborating.html) vignettes. 
+
+### Python 
+
+We recommend keeping the official `conda` [cheat sheet](https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf) handy.
+In addition to the commands included above, a few other commonly used `conda` commands include: 
+
+* `conda deactivate` deactivates the current environment  
+* `conda list` lists all packages in the current environment  
+* `conda env list` lists all environments (with the current active environment asterisked)  
+* `conda env remove -n my_env` deletes the `my_env` environment 
+
+The official [documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) and [this guide](https://carpentries-incubator.github.io/introduction-to-conda-for-data-scientists/04-sharing-environments/index.html) from the Carpentries are also helpful resources. 
+
+:::

--- a/index.qmd
+++ b/index.qmd
@@ -1,5 +1,7 @@
 ---
 title: Virtual Environments
+subtitle: Introduction to Virtual Environments with R and Python at the Urban Institute
+author: Erika Tyagi
 date: "`r format(Sys.time(), '%d %B, %Y')`"
 format:
   html:
@@ -53,7 +55,7 @@ If you're using R alongside Python, it may make sense to use `conda` as your env
 ### Alternatives for Python
 There is a plethora of virtual environment managers in Python, with a few of the most common being `virtualenv`, `pipenv`, `poetry`, and `conda`. 
 
-For data science and research use cases, `conda` is a popular option for several reasons. First, `conda` is both an environment manager and a package manager. As a result, `conda` helps install packages and manage dependencies, whereas the others still rely on `pip` for package management. Unlike other managers, `conda` also has native support for programming languages beyond Python (including R). Lastly, `conda` is flexible, letting you install packages from `pip` and offering [Miniconda](https://docs.conda.io/en/latest/miniconda.html) as a lighter-weight alternative to the full Anaconda distribution. 
+For data science and research use cases, `conda` is a popular option for several reasons. First, `conda` is both an environment manager and a package manager. As a result, `conda` helps install packages and manage dependencies, whereas other tools rely on `pip` for package management. Unlike other managers, `conda` also has native support for programming languages beyond Python (including R). Lastly, `conda` is extensible, letting you install packages from `pip`, for example, and offering [Miniconda](https://docs.conda.io/en/latest/miniconda.html) as a lighter-weight alternative or [Mambda](https://mamba.readthedocs.io/en/latest/index.html) as an even faster "drop-in replacement" for `conda`. 
 
 If you're using R and Python, `conda` or `renv` are good options given their emphasis on interoperability. Documentation for using R with `conda` is available [here](https://docs.anaconda.com/anaconda/user-guide/tasks/using-r-language/), and documentation for using Python with `renv` is available [here](https://rstudio.github.io/renv/articles/python.html). 
 :::

--- a/www/urbn.scss
+++ b/www/urbn.scss
@@ -1,0 +1,152 @@
+/*-- scss:defaults --*/
+$theme: "urbn" !default;
+
+// importing fonts
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata&family=Lato&family=Yanone+Kaffeesatz&display=swap');
+
+//
+// Color system
+//
+
+$white:    #fff !default;
+$gray-100: #f8f9fa !default;
+$gray-200: #e9ecef !default;
+$gray-300: #dee2e6 !default;
+$gray-400: #ced4da !default;
+$gray-500: #adb5bd !default;
+$gray-600: #868e96 !default;
+$gray-700: #495057 !default;
+$gray-800: #343a40 !default;
+$gray-900: #212529 !default;
+$black:    #000 !default;
+
+$cyan:       #1696d2 !default;
+$gray:       #d2d2d2 !default;
+$yellow:     #fdbf11 !default;
+$magenta:    #ec008b !default;
+$space-gray: #5c5859 !default;
+$green:      #55b748 !default;
+$red:        #db2b27 !default;
+
+$primary:       $cyan !default;
+$secondary:     $gray-200 !default;
+$success:       $green !default;
+$info:          $cyan !default;
+$warning:       $yellow !default;
+$danger:        $red !default;
+$light:         $gray-100 !default;
+$dark:          $gray-800 !default;
+
+$min-contrast-ratio:   2.75 !default;
+
+// Body
+
+$body-color:    $gray-700 !default;
+
+// Fonts
+
+$font-family-sans-serif: 'Lato', Tahoma, sans-serif !default;
+$headings-color:         $cyan !default;
+
+// Dropdowns
+
+$dropdown-link-color:           $body-color !default;
+$dropdown-link-hover-color:     $white !default;
+$dropdown-link-hover-bg:        $primary !default;
+
+// Navbar
+
+$navbar-dark-color:             rgba($white, .8) !default;
+$navbar-dark-hover-color:       $white !default;
+
+// Callouts
+$callout-color-note: $cyan;
+$callout-color-warning: $yellow;
+$callout-color-important: $red;
+$callout-color-tip: $green;
+
+
+
+
+/*-- scss:rules --*/
+
+
+// Variables
+
+$text-shadow: 0 1px 0 rgba(0, 0, 0, .05) !default;
+
+// Mixins
+
+@mixin btn-shadow($color){
+  @include gradient-y-three-colors(tint-color($color, 16%), $color, 60%, shade-color($color, 6%));
+}
+
+// Navbar
+
+.navbar {
+  @each $color, $value in $theme-colors {
+    &.bg-#{$color} {
+      @include btn-shadow($value);
+    }
+  }
+}
+
+.navbar-brand,
+.nav-link {
+  text-shadow: $text-shadow;
+}
+
+// Buttons
+
+.btn {
+  text-shadow: $text-shadow;
+}
+
+.btn-secondary {
+  color: $gray-700;
+}
+
+@each $color, $value in $theme-colors {
+  .btn-#{$color} {
+    @include btn-shadow($value);
+  }
+}
+
+// Typography
+
+.text-secondary {
+  color: $gray-500 !important;
+}
+
+.bg-primary,
+.bg-success,
+.bg-info,
+.bg-warning,
+.bg-danger,
+.bg-dark {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: $white;
+  }
+}
+
+// Navs
+
+.dropdown-menu {
+  .dropdown-header {
+    color: $gray-600;
+  }
+}
+
+// Indicators
+
+.badge {
+  &.bg-secondary,
+  &.bg-light {
+    color: $dark;
+  }
+}

--- a/www/web_report.scss
+++ b/www/web_report.scss
@@ -1,0 +1,5 @@
+/*-- scss:defaults --*/
+$font-family-sans-serif: Lato; 
+$font-size-root: 0.5; 
+$code-color: #ec008b; 
+$link-color: #1696d2; 

--- a/www/web_report.scss
+++ b/www/web_report.scss
@@ -1,5 +1,0 @@
-/*-- scss:defaults --*/
-$font-family-sans-serif: Lato; 
-$font-size-root: 0.5; 
-$code-color: #ec008b; 
-$link-color: #1696d2; 


### PR DESCRIPTION
Initial draft of a short guide on using virtual environments for R (`renv`) and Python (`conda`). 

It's fairly opinionated, but (1) coming from a place of wanting to reduce the cognitive load of deciding which environment manager to use, and (2) favoring tools that have strong adoption/support within the broader data science and  reproducible research communities. 

I wanted to figure out how Quarto publishing to GitHub Pages works outside of the watchful eyes of UI-Research admins, but you can see a rendered version on my personal GitHub [here](https://erika-tyagi.github.io/virtual-environments/).  